### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,9 @@ name: Tests
 
 on: [push, pull_request]
 
+permissions:
+    contents: read
+
 jobs:
     tests:
         name: Tests PHP ${{ matrix.php }}


### PR DESCRIPTION
Potential fix for [https://github.com/pompom6784/rsa_compta/security/code-scanning/1](https://github.com/pompom6784/rsa_compta/security/code-scanning/1)

To fix the issue, add an explicit `permissions:` block that grants the least privileges necessary. The workflow only checks out code, installs dependencies, runs analysis/tests, and uploads coverage to an external service using a secret; none of this requires write access to the repository. Therefore, we can safely set `contents: read` at the workflow (root) level so it applies to all jobs, or at the `tests` job level. Root-level is simpler and documents that every job in this workflow is limited.

Concretely, in `.github/workflows/tests.yml`, insert a `permissions:` section after the `on:` block (around line 4) so that the file starts with `name`, `on`, then `permissions`, then `jobs`. The block should be:

```yaml
permissions:
  contents: read
```

No additional imports or definitions are required; this is purely a YAML configuration change for GitHub Actions. Existing functionality remains unchanged because none of the steps need higher permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
